### PR TITLE
Serena Dashboard time, shift, and y-axis changes

### DIFF
--- a/static/js/highcharts.js
+++ b/static/js/highcharts.js
@@ -9,14 +9,14 @@ function requestData() {
         url: '/live-data',
         success: function(point) {
             var series = chart.series[0],
-                shift = series.data.length > 20; // shift if the series is
-                                                 // longer than 20
+                shift = series.data.length > 100; // shift if the series is
+                                                 // longer than 100
 
             // add the point
             chart.series[0].addPoint(point, true, shift);
 
             // call it again after one second
-            setTimeout(requestData, 5000);
+            setTimeout(requestData, 1000);
         },
         cache: false
     });
@@ -42,6 +42,8 @@ $(document).ready(function() {
         yAxis: {
             minPadding: 0.2,
             maxPadding: 0.2,
+			min:0,
+			max:100,
             title: {
                 text: 'Value',
                 margin: 80


### PR DESCRIPTION
Changed the shift variable threshold so the chart will display 100
points instead of 20 before dropping the earlier points. Also, changed
the timeout variable to 1 second instead of 5 seconds. And finally, set
the min and max of the chart. The data being charted is implicitly
between 0 and 100; I just set the chart to those min and max at the
start.